### PR TITLE
Update vscode-textmate-languageservice to 0.2.1

### DIFF
--- a/misc/vscode/package-lock.json
+++ b/misc/vscode/package-lock.json
@@ -8,7 +8,7 @@
             "name": "onyx",
             "version": "0.0.2",
             "dependencies": {
-                "vscode-textmate-languageservice": "0.2.0"
+                "vscode-textmate-languageservice": "0.2.1"
             },
             "devDependencies": {
                 "vscode": "^1.1.37"
@@ -693,9 +693,9 @@
             "dev": true
         },
         "node_modules/vscode-textmate-languageservice": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-textmate-languageservice/-/vscode-textmate-languageservice-0.2.0.tgz",
-            "integrity": "sha512-apMHN5DH/eAORvDBXkcXC5iCFt5U5nIwTRumH7DazbFBv63+82gf5tW/xY+o978xuPWGXp4YySFKwfbvMCZTdA==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/vscode-textmate-languageservice/-/vscode-textmate-languageservice-0.2.1.tgz",
+            "integrity": "sha512-E0SyOKmK2DbtINhVeskWbQMWOUs7POek25C3Y3FqluoNq+e4UkeIVM34MU2WR5G18C+xLuQRoA3Hjev3e/4HeA==",
             "dependencies": {
                 "delay": "^5.0.0",
                 "git-sha1": "^0.1.2",
@@ -1245,9 +1245,9 @@
             }
         },
         "vscode-textmate-languageservice": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/vscode-textmate-languageservice/-/vscode-textmate-languageservice-0.2.0.tgz",
-            "integrity": "sha512-apMHN5DH/eAORvDBXkcXC5iCFt5U5nIwTRumH7DazbFBv63+82gf5tW/xY+o978xuPWGXp4YySFKwfbvMCZTdA==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/vscode-textmate-languageservice/-/vscode-textmate-languageservice-0.2.1.tgz",
+            "integrity": "sha512-E0SyOKmK2DbtINhVeskWbQMWOUs7POek25C3Y3FqluoNq+e4UkeIVM34MU2WR5G18C+xLuQRoA3Hjev3e/4HeA==",
             "requires": {
                 "delay": "^5.0.0",
                 "git-sha1": "^0.1.2",

--- a/misc/vscode/package.json
+++ b/misc/vscode/package.json
@@ -54,7 +54,7 @@
     },
     "files": ["./textmate-configuration.json"],
     "dependencies": {
-        "vscode-textmate-languageservice": "0.2.0"
+        "vscode-textmate-languageservice": "0.2.1"
     },
     "devDependencies": {
         "vscode": "^1.1.37"


### PR DESCRIPTION
Fixes performance regressions as explained in SNDST00M/vscode-textmate-languageservice#12.