### PR TITLE
Updated vscode-textmate-languageservice to 0.2.3

### DIFF
--- a/misc/vscode/package-lock.json
+++ b/misc/vscode/package-lock.json
@@ -8,7 +8,7 @@
             "name": "onyx",
             "version": "0.0.2",
             "dependencies": {
-                "vscode-textmate-languageservice": "0.2.1"
+                "vscode-textmate-languageservice": "0.2.3"
             },
             "devDependencies": {
                 "vscode": "^1.1.37"
@@ -693,9 +693,9 @@
             "dev": true
         },
         "node_modules/vscode-textmate-languageservice": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/vscode-textmate-languageservice/-/vscode-textmate-languageservice-0.2.1.tgz",
-            "integrity": "sha512-E0SyOKmK2DbtINhVeskWbQMWOUs7POek25C3Y3FqluoNq+e4UkeIVM34MU2WR5G18C+xLuQRoA3Hjev3e/4HeA==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/vscode-textmate-languageservice/-/vscode-textmate-languageservice-0.2.3.tgz",
+            "integrity": "sha512-XtMqSPRm7F3V7D/Kz2X3GjKyenAqWu+ik1Q7WfxcgLfCq1P2Hz/wUiRbiJWtT2bHV4cEjzKEfbHpHr6ImqN3yA==",
             "dependencies": {
                 "delay": "^5.0.0",
                 "git-sha1": "^0.1.2",
@@ -1245,9 +1245,9 @@
             }
         },
         "vscode-textmate-languageservice": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/vscode-textmate-languageservice/-/vscode-textmate-languageservice-0.2.1.tgz",
-            "integrity": "sha512-E0SyOKmK2DbtINhVeskWbQMWOUs7POek25C3Y3FqluoNq+e4UkeIVM34MU2WR5G18C+xLuQRoA3Hjev3e/4HeA==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/vscode-textmate-languageservice/-/vscode-textmate-languageservice-0.2.3.tgz",
+            "integrity": "sha512-XtMqSPRm7F3V7D/Kz2X3GjKyenAqWu+ik1Q7WfxcgLfCq1P2Hz/wUiRbiJWtT2bHV4cEjzKEfbHpHr6ImqN3yA==",
             "requires": {
                 "delay": "^5.0.0",
                 "git-sha1": "^0.1.2",

--- a/misc/vscode/package.json
+++ b/misc/vscode/package.json
@@ -54,7 +54,7 @@
     },
     "files": ["./textmate-configuration.json"],
     "dependencies": {
-        "vscode-textmate-languageservice": "0.2.1"
+        "vscode-textmate-languageservice": "0.2.3"
     },
     "devDependencies": {
         "vscode": "^1.1.37"


### PR DESCRIPTION
Fixes folding provider regressions as explained in SNDST00M/vscode-textmate-languageservice#21.